### PR TITLE
add no-floating-promises to node preset

### DIFF
--- a/node.json
+++ b/node.json
@@ -21,6 +21,7 @@
     "object-literal-sort-keys": false,
     "trailing-comma": false,
     "no-console": false,
+    "no-floating-promises": true,
     "indent": {
       "options": [
         "spaces",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "zaius-tslint",
-  "version": "1.0.0",
+  "name": "@zaiusinc/tslint-presets",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/tslint-presets",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/tslint-presets",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Zaius preferred TSLint rules",
   "main": "node.json",
   "repository": "https://github.com/ZaiusInc/tslint-presets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/tslint-presets",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Zaius preferred TSLint rules",
   "main": "node.json",
   "repository": "https://github.com/ZaiusInc/tslint-presets",


### PR DESCRIPTION
Not entirely sure of the impact on other projects, but this has been extremely helpful in ZIP apps that make heavy use of promises.

Thoughts on adding this to the base tslint rules? can always be disabled/overridden i suppose, but I think this is a great best practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/tslint-presets/2)
<!-- Reviewable:end -->
